### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/comunidades.wairbot.es/admin/js/onLoad.js
+++ b/comunidades.wairbot.es/admin/js/onLoad.js
@@ -16,11 +16,12 @@ function mostrarSection(section) {
     document.getElementById(section).style.display = 'flex';
 
     let thisUrl = window.location.href;
+    let sanitizedUrl = encodeURIComponent(thisUrl);
     
     if(section === 'login'){
         let htmlLogin = `
             <form>
-                <img src="${thisUrl}/imgs/logo.svg" alt="Logo" class="logo">
+                <img src="${sanitizedUrl}/imgs/logo.svg" alt="Logo" class="logo">
                 <h2>LOGIN</h2>
                 <div class="inputGroup">
                     <label>Usuario o email</label>


### PR DESCRIPTION
Potential fix for [https://github.com/SiliconValleyVigo/wairbot.es/security/code-scanning/2](https://github.com/SiliconValleyVigo/wairbot.es/security/code-scanning/2)

To fix the issue, we need to sanitize or encode the `window.location.href` value before using it in the `htmlLogin` string. The best approach is to use a library like `DOMPurify` to sanitize the value or encode it using `encodeURIComponent` or similar methods. This ensures that any malicious input is neutralized before being rendered in the DOM.

Specifically:
1. Import a library like `DOMPurify` or use a built-in encoding function.
2. Sanitize or encode the `thisUrl` value before including it in the `htmlLogin` string.
3. Replace the vulnerable code on line 23 with the sanitized or encoded value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
