### PR TITLE
Potential fix for code scanning alert no. 4: Client-side cross-site scripting

### DIFF
--- a/pruebasbot.wairbot.es/acitui/js/onLoad.js
+++ b/pruebasbot.wairbot.es/acitui/js/onLoad.js
@@ -1,6 +1,14 @@
 //comprobar si hay token en localstorage
 let token = localStorage.getItem('token');
 
+function encodeHTML(str) {
+    return str.replace(/&/g, "&amp;")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;")
+              .replace(/"/g, "&quot;")
+              .replace(/'/g, "&#39;");
+}
+
 if (token === null || token === undefined || token === 'undefined' || token === '' || token === 'null') {
     mostrarSection('login');
 } else {
@@ -16,11 +24,12 @@ function mostrarSection(section) {
     document.getElementById(section).style.display = 'flex';
 
     let thisUrl = window.location.href;
+    let sanitizedUrl = encodeHTML(thisUrl);
 
     if (section === 'login') {
         let htmlLogin = `
             <form id="formLogin" style="display: flex;">
-                <img src="${thisUrl}/imgs/logo.svg" alt="Logo" class="logo">
+                <img src="${sanitizedUrl}/imgs/logo.svg" alt="Logo" class="logo">
                 <h2>LOGIN</h2>
                 <div class="inputGroup">
                     <label>Usuario o email</label>


### PR DESCRIPTION
Potential fix for [https://github.com/SiliconValleyVigo/wairbot.es/security/code-scanning/4](https://github.com/SiliconValleyVigo/wairbot.es/security/code-scanning/4)

To fix the issue, the value of `thisUrl` should be sanitized or encoded before being embedded in the HTML. Specifically:
1. Use a library or built-in function to encode the value of `thisUrl` for safe use in an HTML context. This ensures that any special characters in the URL are properly escaped.
2. Replace the direct interpolation of `thisUrl` in the `src` attribute with the sanitized/encoded version.

The fix will involve:
- Adding a utility function to encode the URL for safe use in HTML.
- Replacing the direct use of `thisUrl` in the `src` attribute with the encoded version.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
