### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/toedo.wairbot.es/js/users/administrador/vendidos.js
+++ b/toedo.wairbot.es/js/users/administrador/vendidos.js
@@ -727,6 +727,14 @@ async function imprimirTicket() {
   }
 
   let tareasHtml = "";
+  // Utility function to escape HTML special characters
+  function escapeHTML(str) {
+    return str.replace(/[&<>"']/g, function (char) {
+      const escapeChars = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+      return escapeChars[char];
+    });
+  }
+
   for (let tarea of tareas){
     //si tarea tipo comienza por tres caracteres numéricos borra los tres primeros caracteres y el espacio
     if (tarea.tipo.substring(0, 3).match(/\d/g)) {
@@ -750,10 +758,10 @@ async function imprimirTicket() {
 
     tareasHtml += `
       <div style="display: flex; justify-content: space-between;">
-        <div>${tarea.tipo}</div>
-        <div>${tarea.descripcion}</div>
-        <div>${tarea.referencia}</div>
-        <div>${tarea.coste}</div>
+        <div>${escapeHTML(tarea.tipo)}</div>
+        <div>${escapeHTML(tarea.descripcion)}</div>
+        <div>${escapeHTML(tarea.referencia)}</div>
+        <div>${escapeHTML(tarea.coste)}</div>
       </div>
     `;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/SiliconValleyVigo/wairbot.es/security/code-scanning/13](https://github.com/SiliconValleyVigo/wairbot.es/security/code-scanning/13)

To fix the issue, we need to ensure that any untrusted input is properly escaped before being included in the HTML. Escaping ensures that special characters like `<`, `>`, and `&` are treated as plain text rather than HTML or JavaScript. The best way to achieve this is to use a utility function to escape the input values before appending them to the `tareasHtml` string.

We will:
1. Create a utility function `escapeHTML` to escape special characters in strings.
2. Use this function to sanitize all dynamic values (`tarea.tipo`, `tarea.descripcion`, `tarea.referencia`, and `tarea.coste`) before including them in the `tareasHtml` string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
